### PR TITLE
Add new .png files to Makefile.am

### DIFF
--- a/qucs/qucs/bitmaps/Makefile.am
+++ b/qucs/qucs/bitmaps/Makefile.am
@@ -180,6 +180,7 @@ PNG = \
 	rect.png \
 	redo.png \
 	relais.png \
+	RemoveElementTuning.png \
 	resistor.png \
 	resistor_us.png \
 	rfedd.png \
@@ -215,6 +216,7 @@ PNG = \
 	transformer.png \
 	triac.png \
 	truth.png \
+	tune.png \
 	tunneldiode.png \
 	twistedpair.png \
 	undo.png \


### PR DESCRIPTION
After adding those `.png` files to `qucs/qucs/bitmaps/Makefile.am`, `make distcheck` is running fine here.

BTW, could you please enable "allow edits from maintainers" to your PR (you should see a checkbox for this on the right sidebar) so we can directly add these small things without needing a PR to your branch, thanks!